### PR TITLE
fix: next.js hydration ui diff 문제 수정

### DIFF
--- a/components/common/Header/Menu.tsx
+++ b/components/common/Header/Menu.tsx
@@ -11,6 +11,8 @@ import IconKakao from '@/public/icons/icon-kakao-logo.svg';
 import IconMail from '@/public/icons/icon-mail-logo.svg';
 import IconYoutube from '@/public/icons/icon-youtube-logo.svg';
 
+const SOPT_RECRUIT_LINK = 'https://sopt-recruiting.web.app/recruiting/apply/ob';
+
 const ICONS = [
   {
     icon: <IconMail />,
@@ -34,7 +36,12 @@ const ICONS = [
   },
 ];
 
-const MenuItems = [
+interface MenuItem {
+  url: string;
+  text: string;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+}
+const MenuItems: MenuItem[] = [
   {
     url: '/',
     text: '홈',
@@ -54,6 +61,10 @@ const MenuItems = [
   {
     url: '/recruit',
     text: '신입회원모집',
+    onClick: (e) => {
+      e.preventDefault();
+      window.location.href = SOPT_RECRUIT_LINK;
+    },
   },
   {
     url: '/partners',
@@ -75,8 +86,8 @@ const Menu: FC<MenuProps> = ({ isOpen, onToggle }) => {
         <StyledIcon onClick={onToggle} />
         <ContentsWrap>
           <MenuTitlesWrap>
-            {MenuItems.map(({ url, text }) => (
-              <MenuTitle key={url} href={url} active={router.asPath === url}>
+            {MenuItems.map(({ url, text, onClick }) => (
+              <MenuTitle key={url} href={url} onClick={(e) => onClick?.(e)} active={router.pathname === url}>
                 {text}
               </MenuTitle>
             ))}

--- a/components/common/Header/Menu.tsx
+++ b/components/common/Header/Menu.tsx
@@ -11,7 +11,6 @@ import IconKakao from '@/public/icons/icon-kakao-logo.svg';
 import IconMail from '@/public/icons/icon-mail-logo.svg';
 import IconYoutube from '@/public/icons/icon-youtube-logo.svg';
 
-const SOPT_RECRUIT_LINK = 'https://sopt-recruiting.web.app/recruiting/apply/ob';
 const ICONS = [
   {
     icon: <IconMail />,
@@ -35,6 +34,33 @@ const ICONS = [
   },
 ];
 
+const MenuItems = [
+  {
+    url: '/',
+    text: '홈',
+  },
+  {
+    url: '/about',
+    text: 'SOPT소개',
+  },
+  {
+    url: '/history',
+    text: '역대기수소개',
+  },
+  {
+    url: '/projects',
+    text: '프로젝트',
+  },
+  {
+    url: '/recruit',
+    text: '신입회원모집',
+  },
+  {
+    url: '/partners',
+    text: '협력사',
+  },
+];
+
 interface MenuProps {
   isOpen: boolean;
   onToggle: () => void;
@@ -49,34 +75,11 @@ const Menu: FC<MenuProps> = ({ isOpen, onToggle }) => {
         <StyledIcon onClick={onToggle} />
         <ContentsWrap>
           <MenuTitlesWrap>
-            <MenuTitle href='/' isSelected={router.pathname === '/'}>
-              홈
-            </MenuTitle>
-            <MenuTitle href='/about' isSelected={router.pathname === '/about'}>
-              SOPT소개
-            </MenuTitle>
-            <MenuTitle href='/history' isSelected={router.pathname === '/history'}>
-              역대기수소개
-            </MenuTitle>
-            <MenuTitle href='/projects' isSelected={router.pathname === '/projects'}>
-              프로젝트
-            </MenuTitle>
-            <MenuTitle href='/recruit' isSelected={router.pathname === '/recruit'}>
-              <a
-                style={{
-                  color: 'inherit',
-                }}
-                onClick={(e) => {
-                  e.preventDefault();
-                  window.location.href = SOPT_RECRUIT_LINK;
-                }}
-              >
-                신입회원모집
-              </a>
-            </MenuTitle>
-            <MenuTitle href='/partners' isSelected={router.pathname === '/partners'}>
-              협력사
-            </MenuTitle>
+            {MenuItems.map(({ url, text }) => (
+              <MenuTitle key={url} href={url} active={router.asPath === url}>
+                {text}
+              </MenuTitle>
+            ))}
           </MenuTitlesWrap>
           <BottomWrap>
             <Rules href='/rules'>SOPT 회칙</Rules>
@@ -183,7 +186,7 @@ const MenuTitlesWrap = styled.div`
   padding-bottom: 30px;
 `;
 
-const MenuTitle = styled.a<{ isSelected: boolean }>`
+const MenuTitle = styled.a<{ active: boolean }>`
   outline: none;
   cursor: pointer;
   padding-bottom: 4px;
@@ -197,8 +200,8 @@ const MenuTitle = styled.a<{ isSelected: boolean }>`
   font-weight: 500;
 
   /* TODO: main-color 수정 */
-  ${({ isSelected }) =>
-    isSelected &&
+  ${({ active }) =>
+    active &&
     css`
       border-bottom: 3px solid ${colors.purple100};
       color: ${colors.white};

--- a/next.config.js
+++ b/next.config.js
@@ -30,18 +30,4 @@ const nextConfig = {
   },
 };
 
-// https://nextjs.org/docs/api-reference/next.config.js/redirects
-const SOPT_RECRUIT_LINK = 'https://sopt-recruiting.web.app/recruiting/apply/ob';
-
-module.exports = {
-  ...nextConfig,
-  async redirects() {
-    return [
-      {
-        source: '/recruit',
-        destination: SOPT_RECRUIT_LINK,
-        permanent: false,
-      },
-    ];
-  },
-};
+module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -30,4 +30,18 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+// https://nextjs.org/docs/api-reference/next.config.js/redirects
+const SOPT_RECRUIT_LINK = 'https://sopt-recruiting.web.app/recruiting/apply/ob';
+
+module.exports = {
+  ...nextConfig,
+  async redirects() {
+    return [
+      {
+        source: '/recruit',
+        destination: SOPT_RECRUIT_LINK,
+        permanent: false,
+      },
+    ];
+  },
+};


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #44

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- `MenuItem`들을 상수화한 다음 map으로 뿌리도록 변경했어요.
- <a>태그 안에 <a>태그를 중첩으로 사용해서 생기는 문제였어요..!! (https://github.com/vercel/next.js/issues/36765)

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->
~- 사실 왜 해결된지 정확히 잘 모르겠어요..😭 기존엔 `router.pathname`이 서버에서 정의되기 이전에의 ui `(isSelected === false)`와 hydration 이후의 ui `(isSelected === true)` 여서 렌더링되는 색상이 달라서 생기는 문제인 줄 알았으나, 바뀐 코드도 사실 원래의 코드와 다를게 없지 않나..? 하는 생각이에요. (코드 정리하려고 저렇게 바꾸고 보니 해당 이슈가 해결되었어요,, 흠)~
- `Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.`와 같은 에러가 발생하고 있었는데요([a 태그를 중첩해서 사용하지 않는 이유](https://stackoverflow.com/questions/18666915/why-are-nested-anchor-tags-illegal)), 이 때문에 서버에서 html을 생성할 땐 정상적인 html의 구조대로 렌더링하지만, 브라우저에서 생성할 땐 정상으로 판단하여 그대로 파싱해와서 이 둘의 ui 구조가 달라져서 생기는 이슈입니다.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="480" alt="image" src="https://user-images.githubusercontent.com/26808056/194131556-f159af73-a478-49ec-9f14-00340a738dde.png">

