### PR TITLE
복사될 회원가입 링크 및 토스트 디자인 적용

### DIFF
--- a/components/projects/upload/SignupLink/index.tsx
+++ b/components/projects/upload/SignupLink/index.tsx
@@ -10,7 +10,7 @@ import { copyToClipboard } from '@/utils';
 const SignupLink: FC = () => {
   const { showToast } = useContext(ToastContext);
   const onCopy = () =>
-    copyToClipboard('회원가입 링크', {
+    copyToClipboard('https://sopt-project.pages.dev/auth/verify', {
       onSuccess: () => showToast('링크가 클립보드에 저장되었습니다'),
       onError: () => showToast('다시 시도해주세요'),
     });

--- a/components/projects/upload/SignupLink/index.tsx
+++ b/components/projects/upload/SignupLink/index.tsx
@@ -7,10 +7,12 @@ import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { copyToClipboard } from '@/utils';
 
+const ORIGIN = process.env.NEXT_PUBLIC_ORIGIN;
+
 const SignupLink: FC = () => {
   const { showToast } = useContext(ToastContext);
   const onCopy = () =>
-    copyToClipboard(`${process.env.NEXT_PUBLIC_ORIGIN}/auth/verify`, {
+    copyToClipboard(`${ORIGIN}/auth/verify`, {
       onSuccess: () => showToast('링크가 클립보드에 저장되었습니다'),
       onError: () => showToast('다시 시도해주세요'),
     });

--- a/components/projects/upload/SignupLink/index.tsx
+++ b/components/projects/upload/SignupLink/index.tsx
@@ -10,7 +10,7 @@ import { copyToClipboard } from '@/utils';
 const SignupLink: FC = () => {
   const { showToast } = useContext(ToastContext);
   const onCopy = () =>
-    copyToClipboard('https://sopt-project.pages.dev/auth/verify', {
+    copyToClipboard(`${process.env.NEXT_PUBLIC_ORIGIN}/auth/verify`, {
       onSuccess: () => showToast('링크가 클립보드에 저장되었습니다'),
       onError: () => showToast('다시 시도해주세요'),
     });

--- a/components/projects/upload/ToastProvider/index.tsx
+++ b/components/projects/upload/ToastProvider/index.tsx
@@ -3,6 +3,7 @@ import { createContext, FC, ReactNode, useRef, useState } from 'react';
 import { useEffect } from 'react';
 
 import { ToastStatus } from '@/components/projects/upload/ToastProvider/types';
+import { colors } from '@/styles/colors';
 import { TimeoutID } from '@/types';
 
 export const ToastContext = createContext<{ showToast: (message: string) => void }>({
@@ -57,37 +58,46 @@ export const ToastProvider: FC<ToastProviderProps> = ({ duration = 1000, childre
 
 const StyledContainer = styled.div`
   position: fixed;
-  top: 0;
-  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 100;
 `;
 
 const StyledToastItem = styled.div<{ animation: string }>`
   position: sticky;
-  top: 10px;
+  bottom: 71px;
+  left: 36px;
   margin: 20px 14px;
-  background-color: white;
-  padding: 20px;
+  border-radius: 8px;
+  background: #fff;
+  padding-top: 13px;
+  padding-bottom: 13px;
+  padding-left: 24px;
+  width: 343px;
   animation: 0.3s forwards ${(props) => props.animation};
+  line-height: 136%;
   color: black;
+  color: ${colors.gray80};
+  font-size: 16px;
+  font-weight: 500;
 
   @keyframes slide-in {
     from {
-      transform: translateX(300%);
+      transform: translateY(300%);
     }
 
     to {
-      transform: translateX(0%);
+      transform: translateY(0%);
     }
   }
 
   @keyframes slide-out {
     from {
-      transform: translateX(0%);
+      transform: translateY(0%);
     }
 
     to {
-      transform: translateX(300%);
+      transform: translateY(300%);
     }
   }
 `;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #59

### 🧐 어떤 것을 변경했어요~?
- https://github.com/sopt-makers/sopt-internal-frontend/pull/54 에서 임의로 했던 부분들 수정
  - 복사될 텍스트를 실제 회원가입 링크로 적용
  - 디자인 없이 만들었던 토스트 디자인 적용

### 🤔 그렇다면, 어떻게 구현했어요~?
- 복사될 텍스트를 실제 회원가입 링크로 적용
  - 지금 배포돼있는 링크로 했음
    
- 디자인 없이 만들었던 토스트 디자인 적용 
  - 전반적인 스타일 및 애니메이션 예린이가 디자인 해준 것으로 수정

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
- 복사될 텍스트를 실제 회원가입 링크로 적용
  - 건영이가 https://github.com/sopt-makers/sopt-internal-frontend/issues/62 하고 나면 경로 자체가 바뀔수도 있을 것 같고, 도메인 구매하면 또 바꾸어야 합니다
  - 도메인 확정되고 나면 상수로 빼면 좋을 것 같어요
  
### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
스토리북에서 보셔요 ~ !