### PR TITLE
fix: 로그인 오류 수정

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_ORIGIN=http://localhost:3000
 NEXT_PUBLIC_FACEBOOK_APP_ID=520253793038775
-NEXT_PUBLIC_AUTH_API_URL=https://api.sopt-playground.ga/auth/api/v1
-NEXT_PUBLIC_API_URL=https://api.sopt-playground.ga/project/api/v1
+NEXT_PUBLIC_AUTH_API_URL=https://api.sopt-playground.ga/auth
+NEXT_PUBLIC_API_URL=https://api.sopt-playground.ga/project

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_ORIGIN=http://localhost:3000
 NEXT_PUBLIC_FACEBOOK_APP_ID=520253793038775
-NEXT_PUBLIC_AUTH_API_URL=http://api.sopt-playground.ga:5000
-NEXT_PUBLIC_API_URL=http://api.sopt-playground.ga:4000
+NEXT_PUBLIC_AUTH_API_URL=https://api.sopt-playground.ga/auth/api/v1
+NEXT_PUBLIC_API_URL=https://api.sopt-playground.ga/project/api/v1

--- a/components/auth/identityProvider/useFacebookAuth.ts
+++ b/components/auth/identityProvider/useFacebookAuth.ts
@@ -4,8 +4,8 @@ import useStateParam from '@/components/auth/useStateParam';
 const ORIGIN = process.env.NEXT_PUBLIC_ORIGIN;
 const FACEBOOK_APP_ID = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID ?? '';
 
-const FACEBOOK_LOGIN_CALLBACK_URI = `${ORIGIN}/auth/cb/facebook/login`;
-const FACEBOOK_REGISTER_CALLBACK_URI = `${ORIGIN}/auth/cb/facebook/register`;
+const FACEBOOK_LOGIN_CALLBACK_URI = `${ORIGIN}/auth/callback/facebook/login`;
+const FACEBOOK_REGISTER_CALLBACK_URI = `${ORIGIN}/auth/callback/facebook/register`;
 
 interface FacebookAuth {
   login(): void;


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #69 

### 🧐 어떤 것을 변경했어요~?

저번에 #61 에서 리팩터링 할 때 디렉터리 이름이 바뀌면서 API Route도 같이 바뀌었는데, 이게 반영이 안되어서 페이스북 로그인이 실패하는 현상을 수정했습니다.

추가로 .env.development 파일의 내용이 최신이 아니어서 이것도 수정했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?

페이스북 로그인 페이지로 이동할 때 들어가는 콜백 인자의 주소를 변경했습니다.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
