### PR TITLE
프로젝트 업로드 폼 자잘한 버그 fix

### DIFF
--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -6,18 +6,27 @@ import Text from '@/components/common/Text';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value'> {
   error?: boolean;
   count?: boolean;
   maxCount?: number;
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, maxCount, ...props }, ref) => {
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, maxCount, onChange, ...props }, ref) => {
   const [value, setValue] = useState<string>('');
 
   return (
     <>
-      <StyledInput value={value} onChange={(e) => setValue(e.target.value)} error={error} ref={ref} {...props} />
+      <StyledInput
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          onChange?.(e);
+        }}
+        error={error}
+        ref={ref}
+        {...props}
+      />
       {count && (
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>

--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -17,7 +17,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, m
 
   return (
     <>
-      <StyledInput {...props} value={value} onChange={(e) => setValue(e.target.value)} error={error} ref={ref} />
+      <StyledInput value={value} onChange={(e) => setValue(e.target.value)} error={error} ref={ref} {...props} />
       {count && (
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>

--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -17,7 +17,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, m
 
   return (
     <>
-      <StyledInput value={value} onChange={(e) => setValue(e.target.value)} error={error} ref={ref} {...props} />
+      <StyledInput {...props} value={value} onChange={(e) => setValue(e.target.value)} error={error} ref={ref} />
       {count && (
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>

--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -18,7 +18,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, m
   return (
     <>
       <StyledInput
-        value={props.value ?? value}
         onChange={(e) => {
           setValue(e.target.value);
           onChange?.(e);

--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -6,7 +6,7 @@ import Text from '@/components/common/Text';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value'> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
   count?: boolean;
   maxCount?: number;
@@ -18,7 +18,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, m
   return (
     <>
       <StyledInput
-        value={value}
+        value={props.value ?? value}
         onChange={(e) => {
           setValue(e.target.value);
           onChange?.(e);

--- a/components/common/TextArea/index.tsx
+++ b/components/common/TextArea/index.tsx
@@ -6,7 +6,7 @@ import Text from '@/components/common/Text';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-interface TextAreaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'> {
+interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   error?: boolean;
   count?: boolean;
   maxCount?: number;
@@ -17,7 +17,7 @@ const TextArea: FC<PropsWithChildren<TextAreaProps>> = ({ count, maxCount, error
   return (
     <>
       <StyledTextArea
-        value={value}
+        value={props.value ?? value}
         onChange={(e) => {
           setValue(e.target.value);
           onChange?.(e);

--- a/components/common/TextArea/index.tsx
+++ b/components/common/TextArea/index.tsx
@@ -16,7 +16,7 @@ const TextArea: FC<PropsWithChildren<TextAreaProps>> = ({ count, maxCount, error
   const [value, setValue] = useState<string>('');
   return (
     <>
-      <StyledTextArea {...props} value={value} onChange={(e) => setValue(e.target.value)} error={error} />
+      <StyledTextArea value={value} onChange={(e) => setValue(e.target.value)} error={error} {...props} />
       {count && (
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>

--- a/components/common/TextArea/index.tsx
+++ b/components/common/TextArea/index.tsx
@@ -6,17 +6,25 @@ import Text from '@/components/common/Text';
 import { colors } from '@/styles/colors';
 import { textStyles } from '@/styles/typography';
 
-interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface TextAreaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'> {
   error?: boolean;
   count?: boolean;
   maxCount?: number;
 }
 
-const TextArea: FC<PropsWithChildren<TextAreaProps>> = ({ count, maxCount, error, ...props }) => {
+const TextArea: FC<PropsWithChildren<TextAreaProps>> = ({ count, maxCount, error, onChange, ...props }) => {
   const [value, setValue] = useState<string>('');
   return (
     <>
-      <StyledTextArea value={value} onChange={(e) => setValue(e.target.value)} error={error} {...props} />
+      <StyledTextArea
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          onChange?.(e);
+        }}
+        error={error}
+        {...props}
+      />
       {count && (
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>

--- a/components/common/TextArea/index.tsx
+++ b/components/common/TextArea/index.tsx
@@ -17,7 +17,6 @@ const TextArea: FC<PropsWithChildren<TextAreaProps>> = ({ count, maxCount, error
   return (
     <>
       <StyledTextArea
-        value={props.value ?? value}
         onChange={(e) => {
           setValue(e.target.value);
           onChange?.(e);

--- a/components/common/TextArea/index.tsx
+++ b/components/common/TextArea/index.tsx
@@ -16,7 +16,7 @@ const TextArea: FC<PropsWithChildren<TextAreaProps>> = ({ count, maxCount, error
   const [value, setValue] = useState<string>('');
   return (
     <>
-      <StyledTextArea value={value} onChange={(e) => setValue(e.target.value)} error={error} {...props} />
+      <StyledTextArea {...props} value={value} onChange={(e) => setValue(e.target.value)} error={error} />
       {count && (
         <StyledCountValue>
           <Text color={colors.gray100} typography='SUIT_12_M'>

--- a/components/common/form/RHFControllerFormItem.tsx
+++ b/components/common/form/RHFControllerFormItem.tsx
@@ -45,6 +45,7 @@ const RHFControllerFormItem = <
       <Component
         {...({
           error: error || !!fieldState.error,
+          maxLength: props.maxCount,
           ...field,
           ...props,
         } as React.ComponentProps<T>)}


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #84

### 🧐 어떤 것을 변경했어요~?
1. **Input, TextArea 컴포넌트의 count 값이 UI에 업데이트 되지 않는 버그를 고쳤어요**

props가 InputHTMLAttributes을 extends하고 있어서 value와 onChange가 undefined로 덮어씌워지는 것이 문제였습니다
그래서 아래와 같이 Omit으로 props에서 InputHTMLAttributes의 value와 onChange를 빼주는 방식으로 해봤는데 안됐습니다ㅠ
```tsx
export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
  error?: boolean;
  count?: boolean;
  maxCount?: number;
}

export const Input = forwardRef<HTMLInputElement, InputProps>(({ error, count, maxCount, ...props }, ref) => {
  const [value, setValue] = useState<string>('');

  return (
    <>
      <StyledInput value={value} onChange={(e) => setValue(e.target.value)} error={error} ref={ref} {...props} />
      {count && (
        <StyledCountValue>
          <Text color={colors.gray100} typography='SUIT_12_M'>
            {`${value.length}/${maxCount}`}
          </Text>
        </StyledCountValue>
      )}
    </>
  );
});
```

그래서 현재와 같이 props의 순서를 바꾸는 방법으로 고쳤습니다
위 방법이 왜 안되는지 이유를 못찾았는데, 현재 방법으로 해도 문제 없다 생각해서 일단 올렸습니다 ... (왜 안되는지 궁금해요ㅠ)

2. **RHFControllerFormItem 컴포넌트에서 prop으로 받는 컴포넌트에, maxCount prop만큼 value 길이 제한을 해주었어요**
maxLength 설정이 안되고 있던 것이 문제라 추가했습니다