### PR TITLE
feat: 로그인시 이전 화면으로 돌아가기

### DIFF
--- a/components/auth/AuthRequired.tsx
+++ b/components/auth/AuthRequired.tsx
@@ -3,6 +3,7 @@ import { FC, ReactNode, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
+import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 interface AuthRequiredProps {
   children: ReactNode;
@@ -14,13 +15,15 @@ interface AuthRequiredProps {
 const AuthRequired: FC<AuthRequiredProps> = ({ children }) => {
   const router = useRouter();
 
+  const lastUnauthorized = useLastUnauthorized();
   const accessToken = useRecoilValue(accessTokenAtom);
 
   useEffect(() => {
-    if (accessToken === null) {
+    if (router.isReady && accessToken === null) {
+      lastUnauthorized.setPath(router.asPath);
       router.replace('/auth/login');
     }
-  }, [router, accessToken]);
+  }, [router, router.isReady, accessToken, lastUnauthorized]);
 
   return <>{children}</>;
 };

--- a/components/auth/util/useLastUnauthorized.tsx
+++ b/components/auth/util/useLastUnauthorized.tsx
@@ -1,0 +1,16 @@
+const PATH_KEY = 'lastUnauthorizedPath';
+
+const useLastUnauthorized = () => {
+  return {
+    setPath(path: string) {
+      sessionStorage.setItem(PATH_KEY, path);
+    },
+    popPath() {
+      const path = sessionStorage.getItem(PATH_KEY);
+      sessionStorage.removeItem(PATH_KEY);
+      return path;
+    },
+  };
+};
+
+export default useLastUnauthorized;

--- a/pages/auth/callback/facebook/login.tsx
+++ b/pages/auth/callback/facebook/login.tsx
@@ -5,10 +5,12 @@ import { useSetRecoilState } from 'recoil';
 import useFacebookAuth from '@/components/auth/identityProvider/useFacebookAuth';
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import useQueryStringParam from '@/components/auth/useQueryString';
+import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 const FacebookLoginCallbackPage: FC = () => {
   const router = useRouter();
   const facebookAuth = useFacebookAuth();
+  const lastUnauthorized = useLastUnauthorized();
   const setAccessToken = useSetRecoilState(accessTokenAtom);
 
   const [message, setMessage] = useState('');
@@ -21,7 +23,7 @@ const FacebookLoginCallbackPage: FC = () => {
     }
 
     setAccessToken(loginResult.accessToken);
-    router.replace('/');
+    router.replace(lastUnauthorized.popPath() ?? '/');
   });
 
   return (

--- a/pages/auth/callback/facebook/register.tsx
+++ b/pages/auth/callback/facebook/register.tsx
@@ -5,10 +5,12 @@ import { useSetRecoilState } from 'recoil';
 import useFacebookAuth from '@/components/auth/identityProvider/useFacebookAuth';
 import { accessTokenAtom } from '@/components/auth/states/accessTokenAtom';
 import useQueryStringParam from '@/components/auth/useQueryString';
+import useLastUnauthorized from '@/components/auth/util/useLastUnauthorized';
 
 const FacebookRegisterCallbackPage: FC = () => {
   const router = useRouter();
   const facebookAuth = useFacebookAuth();
+  const lastUnauthorized = useLastUnauthorized();
   const setAccessToken = useSetRecoilState(accessTokenAtom);
 
   const [message, setMessage] = useState('');
@@ -23,7 +25,7 @@ const FacebookRegisterCallbackPage: FC = () => {
     }
 
     setAccessToken(registerResult.accessToken);
-    router.replace('/profile/create');
+    router.replace(lastUnauthorized.popPath() ?? '/profile/create');
   });
 
   return (


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #128

### 🧐 어떤 것을 변경했어요~?

이제 로그인 화면으로 강제 이동 후 로그인과 회원가입시, 강제 이동 전에 보고있던 페이지로 이동합니다.

### 🤔 그렇다면, 어떻게 구현했어요~?

강제 이동할때 sessionStorage에 현재 url path를 저장하고, 로그인과 회원가입 성공시 저장된 path로 이동합니다.

URL Query을 안쓰고 sessionStorage를 쓴 이유: OAuth 로그인 플로우의 특징상 여러 origin의 페이지를 옮겨다니게 되는데, 이 과정에서 URL Query를 보존하는 것은 코드가 좀 복잡해집니다. SessionStorage를 사용하고, 로그인 성공시 기존 값을 파기함으로써 간단하게 비슷한 효과를 내게 만들었습니다.


### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
