### PR TITLE
chore: 홈을 /members로 변경

### DIFF
--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -28,8 +28,8 @@ const Header: FC = () => {
         <div className='mobile-only' onClick={() => setIsMobileMenuOpened(true)}>
           <MenuIcon />
         </div>
-        <Link href='/' passHref>
-          <TextLinkButton isCurrentPath={pathname === '/'}>
+        <Link href='/members' passHref>
+          <TextLinkButton isCurrentPath={pathname === '/members'}>
             <StyledLogo>
               <LogoIcon />
             </StyledLogo>

--- a/pages/auth/callback/facebook/login.tsx
+++ b/pages/auth/callback/facebook/login.tsx
@@ -21,7 +21,7 @@ const FacebookLoginCallbackPage: FC = () => {
     }
 
     setAccessToken(loginResult.accessToken);
-    router.replace('/');
+    router.replace('/members');
   });
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,17 @@
 import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 import AuthRequired from '@/components/auth/AuthRequired';
 import Header from '@/components/common/Header';
 import { setLayout } from '@/utils/layout';
 
 const Home: NextPage = () => {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/members');
+  }, [router]);
+
   return <AuthRequired>Home</AuthRequired>;
 };
 


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #131 

### 🧐 어떤 것을 변경했어요~?
기획 상 이슈로 홈을 멤버 페이지로 두어요

- 기존 홈 경로를 모두 /members로 변경
- 홈 접근 시 /members로 리다이렉트

