### PR TITLE
feat: 메인페이지로 접속 시 member 페이지로 redirect

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,10 +10,8 @@ const Home: NextPage = () => {
   const router = useRouter();
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      // MEMO: playground mainpage가 추가되기 전까진 멤버페이지로 redirect 시킵니다.
-      router.push('/members');
-    }
+    // MEMO: playground mainpage가 추가되기 전까진 멤버페이지로 redirect 시킵니다.
+    router.push('/members');
   }, [router]);
 
   return <AuthRequired>{}</AuthRequired>;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,22 @@
 import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 import AuthRequired from '@/components/auth/AuthRequired';
 import Header from '@/components/common/Header';
 import { setLayout } from '@/utils/layout';
 
 const Home: NextPage = () => {
-  return <AuthRequired>Home</AuthRequired>;
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      // MEMO: playground mainpage가 추가되기 전까진 멤버페이지로 redirect 시킵니다.
+      router.push('/members');
+    }
+  }, [router]);
+
+  return <AuthRequired>{}</AuthRequired>;
 };
 
 setLayout(Home, (page) => {


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #131

### 🧐 어떤 것을 변경했어요~?
<!-- 실제로 변경한 사항을 설명해주세요.-->
- 메인페이지로 접속하면 `/members` 페이지로 리다이렉트 시키도록 했습니다.

### 🤔 그렇다면, 어떻게 구현했어요~?
<!-- 실제로 구현한 로직에 대해 설명해주세요.-->
- csr에서 useRouter로 구현했는뎅, https://nextjs.org/docs/api-reference/next.config.js/redirects 이 방법은 우리 배포방식엔 맞지 않아 그렇게 작업했습니당

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
<!-- 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
