### PR TITLE
fix: 이름 옆 전공 대신 파트 정보 뜨도록

### DIFF
--- a/pages/members/detail.tsx
+++ b/pages/members/detail.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import dayjs from 'dayjs';
+import uniq from 'lodash/uniq';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import CallIcon from 'public/icons/icon-call.svg';
@@ -63,7 +64,17 @@ const UserDetailPage: FC = () => {
               <div>
                 <NameWrapper>
                   <div className='name'>{profile?.name}</div>
-                  <div className='part'>{profile?.major}</div>
+                  <div className='part'>
+                    {uniq(
+                      profile?.activities.map((item) => {
+                        const [_, part] = item.cardinalInfo.split(',');
+                        return part;
+                      }),
+                    )
+                      .join('/')
+                      .replace(new RegExp('^/'), '')
+                      .replace(new RegExp('/$'), '')}
+                  </div>
                 </NameWrapper>
                 <div className='intro'>{profile?.introduction}</div>
               </div>

--- a/pages/members/detail.tsx
+++ b/pages/members/detail.tsx
@@ -71,9 +71,8 @@ const UserDetailPage: FC = () => {
                         return part;
                       }),
                     )
-                      .join('/')
-                      .replace(new RegExp('^/'), '')
-                      .replace(new RegExp('/$'), '')}
+                      .filter((part) => part.length)
+                      .join('/')}
                   </div>
                 </NameWrapper>
                 <div className='intro'>{profile?.introduction}</div>


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #142 

### 🧐 어떤 것을 변경했어요~?
프로필 상세 이름 옆에 파트 정보가 뜨도록 했어요

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.
part가 빈 string으로 들어가는 경우가 있는지 uniq 결과물에 빈 string이 있어서 일단 걸러줬습니다
시간 없어서 일단 이대로 배포하는데 요 케이스 원인 나중에 찾아내야 할 것 같아요

### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
<img width="462" alt="image" src="https://user-images.githubusercontent.com/73823388/200106378-6d02bab5-cd28-4736-ba3d-419328dc6f22.png">
