### PR TITLE
fix: 멤버 프로필 링크에서 새로고침되는 현상 수정

### DIFF
--- a/apiHooks/members.ts
+++ b/apiHooks/members.ts
@@ -57,13 +57,10 @@ export const useGetMemberOfMe = () => {
 };
 
 // 멤버 프로필 조회
-export const useGetMemberProfileById = (id: number | null) => {
+export const useGetMemberProfileById = (id: number | undefined) => {
   return useQuery(
     ['getMemberProfileById', id],
     async () => {
-      if (id === null) {
-        throw new Error('Should not be happened');
-      }
       const data = await getMemberProfileById(id);
       return data;
     },

--- a/apiHooks/members.ts
+++ b/apiHooks/members.ts
@@ -57,10 +57,13 @@ export const useGetMemberOfMe = () => {
 };
 
 // 멤버 프로필 조회
-export const useGetMemberProfileById = (id: number | undefined) => {
+export const useGetMemberProfileById = (id: number | null) => {
   return useQuery(
-    ['getMemberProfileById'],
+    ['getMemberProfileById', id],
     async () => {
+      if (id === null) {
+        throw new Error('Should not be happened');
+      }
       const data = await getMemberProfileById(id);
       return data;
     },

--- a/pages/members/detail.tsx
+++ b/pages/members/detail.tsx
@@ -24,7 +24,9 @@ import { setLayout } from '@/utils/layout';
 
 const UserDetailPage: FC = () => {
   const { query, status } = useStringRouterQuery(['memberId'] as const);
-  const { data: profile } = useGetMemberProfileById(status === 'success' ? safeParseInt(query.memberId) : null);
+  const { data: profile } = useGetMemberProfileById(
+    status === 'success' ? safeParseInt(query.memberId) ?? undefined : undefined,
+  );
 
   const is이정연 = profile?.name === '이정연';
   const is김나연 = profile?.name === '김나연';

--- a/pages/members/detail.tsx
+++ b/pages/members/detail.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import dayjs from 'dayjs';
 import uniq from 'lodash/uniq';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import CallIcon from 'public/icons/icon-call.svg';
 import EditIcon from 'public/icons/icon-edit.svg';
 import LinkIcon from 'public/icons/icon-link.svg';
@@ -12,6 +11,7 @@ import { FC } from 'react';
 
 import { useGetMemberProfileById } from '@/apiHooks/members';
 import AuthRequired from '@/components/auth/AuthRequired';
+import useStringRouterQuery from '@/components/auth/useStringRouterQuery';
 import Header from '@/components/common/Header';
 import MobileHeader from '@/components/common/MobileHeader';
 import InfoItem from '@/components/users/detail/InfoItem';
@@ -19,13 +19,12 @@ import PartItem from '@/components/users/detail/PartItem';
 import { colors } from '@/styles/colors';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
+import { safeParseInt } from '@/utils';
 import { setLayout } from '@/utils/layout';
 
 const UserDetailPage: FC = () => {
-  const router = useRouter();
-  const { memberId } = router.query;
-
-  const { data: profile } = useGetMemberProfileById(Number(memberId));
+  const { query, status } = useStringRouterQuery(['memberId'] as const);
+  const { data: profile } = useGetMemberProfileById(status === 'success' ? safeParseInt(query.memberId) : null);
 
   const is이정연 = profile?.name === '이정연';
   const is김나연 = profile?.name === '김나연';

--- a/pages/members/index.tsx
+++ b/pages/members/index.tsx
@@ -65,15 +65,17 @@ const UserPage: FC = () => {
             )} */}
             <StyledCardWrapper>
               {profiles?.map((profile) => (
-                <a key={profile.id} href={`/members/detail?memberId=${profile.id}`}>
-                  <MemberCard
-                    name={profile.name}
-                    part={profile.part}
-                    isActiveGeneration={profile.isActive}
-                    introduction={profile.introduction}
-                    image={profile.profileImage}
-                  />
-                </a>
+                <Link key={profile.id} href={`/members/detail?memberId=${profile.id}`} passHref>
+                  <a>
+                    <MemberCard
+                      name={profile.name}
+                      part={profile.part}
+                      isActiveGeneration={profile.isActive}
+                      introduction={profile.introduction}
+                      image={profile.profileImage}
+                    />
+                  </a>
+                </Link>
               ))}
             </StyledCardWrapper>
           </StyledMain>

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -9,3 +9,12 @@ export const copyToClipboard = async (text: string, options?: { onSuccess?: () =
 };
 
 export const isClientSide = () => typeof window !== 'undefined';
+
+export const safeParseInt = (str: string): number | null => {
+  const value = parseInt(str, 10);
+
+  if (isNaN(value)) {
+    return null;
+  }
+  return value;
+};


### PR DESCRIPTION
### 🤫 쉿, 나한테만 말해줘요. 이슈넘버
- close #151 

### 🧐 어떤 것을 변경했어요~?

멤버 프로필을 누르면 기존에는 사이트가 새로고침 되는 현상이 있었는데, 이 현상을 수정했습니다!

### 🤔 그렇다면, 어떻게 구현했어요~?
- 기존에 a 태그로만 구현했던 링크를, [next/link](https://nextjs.org/docs/api-reference/next/link) 로 감쌌어요.
- query의 변화를 잘 감지하도록 이전 PR에서 만들었던 `useStringRouterQuery` 훅을 사용해서 쿼리를 가져왔어요.
- id가 다른 쿼리 요청이 캐싱되지 않도록 `useQuery`의 첫번째 인자에 id를 추가했어요.

### ❤️‍🔥 당신이 생각하는 PR포인트, 내겐 매력포인트.


### 📸 스크린샷, 없으면 이것 참,, 섭섭한데요?
